### PR TITLE
fix(form-model): Renamed `AbstractFormModel` to `BaseFormModel` across source, tests, and documentation; see `UPGRADE.md` for migration steps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #2: Modernized the package API and documentation, including consistency improvements, structural cleanup, and migration guidance in `UPGRADE.md` (@terabytesoftw)
 - Enh #3: Simplified the form-model field API across public contracts, implementation, tests, and docs (@terabytesoftw)
+- Bug #4: Renamed `AbstractFormModel` to `BaseFormModel` across source, tests, and documentation; see `UPGRADE.md` for migration steps (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $label = $form->getLabel('email');
 
 ## Nested field metadata
 
-You can request metadata using dot notation when a field contains another `AbstractFormModel`.
+You can request metadata using dot notation when a field contains another `BaseFormModel`.
 
 ```php
 $hint = $form->getHint('profile.address.city');

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class SignInForm extends AbstractFormModel
+final class SignInForm extends BaseFormModel
 {
     public string $email = '';
     public string $password = '';
@@ -130,10 +130,12 @@ $rules = $form->getRule('profile.address.city');
 Use first-error mode when you need one message per field.
 
 ```php
-$form->setErrors([
-    'email' => ['Email is required.', 'Email is invalid.'],
-    'password' => ['Password is required.'],
-]);
+$form->setErrors(
+    [
+        'email' => ['Email is required.', 'Email is invalid.'],
+        'password' => ['Password is required.'],
+    ],
+);
 
 $firstErrors = $form->getFirstErrors();
 /*

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,9 @@
     - `getWidgetConfig()` removed
     - `getWidgetConfigByClass(string $class)` removed
 
+6. Renamed base class:
+    - `UIAwesome\FormModel\AbstractFormModel` -> `UIAwesome\FormModel\BaseFormModel`
+
 ### Migration steps
 
 1. Replace old method names in custom form models:
@@ -67,3 +70,21 @@ $model->getFirstError('name');
     - Move any class-level defaults to field-level config in `getFieldConfigs()`.
 
 5. Remove calls to `applyToHtmlRulesByProperty(...)` and move HTML/tag rule application to the field/tag rendering layer.
+
+6. Update base-class inheritance in custom form models:
+
+```php
+// Before
+use UIAwesome\FormModel\AbstractFormModel;
+
+final class MyForm extends AbstractFormModel
+{
+}
+
+// After
+use UIAwesome\FormModel\BaseFormModel;
+
+final class MyForm extends BaseFormModel
+{
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.1",
         "ext-mbstring": "*",
         "php-forge/helper": "^0.2",
-        "ui-awesome/model": "dev-main"
+        "ui-awesome/model": "^0.2@dev"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.32",
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.3.x-dev"
+            "dev-main": "0.2.x-dev"
         }
     },
     "config": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ This guide describes form model conventions and runtime behavior for metadata an
 
 ## Form model declaration
 
-Create form models by extending `AbstractFormModel` and declaring typed public properties that represent fields.
+Create form models by extending `BaseFormModel` and declaring typed public properties that represent fields.
 
 ```php
 <?php
@@ -15,9 +15,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class SignInForm extends AbstractFormModel
+final class SignInForm extends BaseFormModel
 {
     public string $email = '';
     public string $password = '';

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class ContactForm extends AbstractFormModel
+final class ContactForm extends BaseFormModel
 {
     public string $name = '';
     public string $email = '';
@@ -61,9 +61,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class PostForm extends AbstractFormModel
+final class PostForm extends BaseFormModel
 {
     public string $seoTitle = '';
 }
@@ -132,9 +132,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class AddressForm extends AbstractFormModel
+final class AddressForm extends BaseFormModel
 {
     public string $city = '';
 
@@ -144,7 +144,7 @@ final class AddressForm extends AbstractFormModel
     }
 }
 
-final class ProfileForm extends AbstractFormModel
+final class ProfileForm extends BaseFormModel
 {
     public AddressForm $address;
 
@@ -169,9 +169,9 @@ declare(strict_types=1);
 
 namespace App\FormModel;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class LoginForm extends AbstractFormModel
+final class LoginForm extends BaseFormModel
 {
     public string $email = '';
 

--- a/src/BaseFormModel.php
+++ b/src/BaseFormModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\FormModel;
 
 use PHPForge\Helper\WordCaseConverter;
-use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\BaseModel;
 
 /**
  * Base implementation of {@see FormModelInterface}.
@@ -24,7 +24,7 @@ use UIAwesome\Model\AbstractModel;
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-abstract class BaseFormModel extends AbstractModel implements FormModelInterface
+abstract class BaseFormModel extends BaseModel implements FormModelInterface
 {
     /**
      * Lazily initialized field-error storage.

--- a/src/BaseFormModel.php
+++ b/src/BaseFormModel.php
@@ -12,7 +12,7 @@ use UIAwesome\Model\AbstractModel;
  *
  * Usage example:
  * ```php
- * final class UserForm extends AbstractFormModel
+ * final class UserForm extends BaseFormModel
  * {
  *     public string $email = '';
  * }
@@ -24,7 +24,7 @@ use UIAwesome\Model\AbstractModel;
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-abstract class AbstractFormModel extends AbstractModel implements FormModelInterface
+abstract class BaseFormModel extends AbstractModel implements FormModelInterface
 {
     /**
      * Lazily initialized field-error storage.

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -11,7 +11,7 @@ use UIAwesome\Model\ModelInterface;
  *
  * Usage example:
  * ```php
- * final class UserForm extends AbstractFormModel
+ * final class UserForm extends BaseFormModel
  * {
  *     public string $email = '';
  * }

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace UIAwesome\FormModel\Tests;
 
 use PHPUnit\Framework\TestCase;
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 use UIAwesome\FormModel\Tests\Support\Country;
 use UIAwesome\FormModel\Tests\Support\User;
 
 /**
- * Unit tests for form-model metadata and field error behavior via {@see AbstractFormModel} implementations.
+ * Unit tests for form-model metadata and field error behavior via {@see BaseFormModel} implementations.
  *
  * Test coverage.
  * - Adds, clears, and reads field-level validation errors, including first-error extraction.
@@ -89,7 +89,7 @@ final class FormModelTest extends TestCase
 
     public function testGetErrorSummaryWhenEmpty(): void
     {
-        $formModel = new class extends AbstractFormModel {};
+        $formModel = new class extends BaseFormModel {};
 
         self::assertSame([], $formModel->getErrorSummary(), 'Should return an empty summary when no errors exist.');
     }
@@ -137,7 +137,7 @@ final class FormModelTest extends TestCase
 
     public function testGetErrorsWhenEmpty(): void
     {
-        $formModel = new class extends AbstractFormModel {};
+        $formModel = new class extends BaseFormModel {};
 
         self::assertSame([], $formModel->getErrors(), 'Should return an empty error map when no errors exist.');
     }
@@ -230,7 +230,7 @@ final class FormModelTest extends TestCase
 
     public function testGetHintsWhenEmpty(): void
     {
-        $formModel = new class extends AbstractFormModel {};
+        $formModel = new class extends BaseFormModel {};
 
         self::assertEmpty(
             $formModel->getHints(),
@@ -262,7 +262,7 @@ final class FormModelTest extends TestCase
 
     public function testGetLabelsWhenEmpty(): void
     {
-        $formModel = new class extends AbstractFormModel {};
+        $formModel = new class extends BaseFormModel {};
 
         self::assertSame(
             [],
@@ -295,7 +295,7 @@ final class FormModelTest extends TestCase
 
     public function testGetPlaceholdersWhenEmpty(): void
     {
-        $formModel = new class extends AbstractFormModel {};
+        $formModel = new class extends BaseFormModel {};
 
         self::assertEmpty(
             $formModel->getPlaceholders(),

--- a/tests/Support/Address.php
+++ b/tests/Support/Address.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\FormModel\Tests\Support;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class Address extends AbstractFormModel
+final class Address extends BaseFormModel
 {
     public string $city = '';
     public Country $country;

--- a/tests/Support/Country.php
+++ b/tests/Support/Country.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\FormModel\Tests\Support;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class Country extends AbstractFormModel
+final class Country extends BaseFormModel
 {
     public string $name = '';
     private string $postalCode = '';

--- a/tests/Support/Profile.php
+++ b/tests/Support/Profile.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\FormModel\Tests\Support;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class Profile extends AbstractFormModel
+final class Profile extends BaseFormModel
 {
     public Address $address;
     public string $bio = '';

--- a/tests/Support/User.php
+++ b/tests/Support/User.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\FormModel\Tests\Support;
 
-use UIAwesome\FormModel\AbstractFormModel;
+use UIAwesome\FormModel\BaseFormModel;
 
-final class User extends AbstractFormModel
+final class User extends BaseFormModel
 {
     public string $name = '';
     public Profile $profile;


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
